### PR TITLE
Fixed yahoo calendar generator

### DIFF
--- a/src/Generators/Yahoo.php
+++ b/src/Generators/Yahoo.php
@@ -12,8 +12,8 @@ class Yahoo implements Generator
         $url = 'https://calendar.yahoo.com/?v=60&view=d&type=20';
 
         $url .= '&title='.urlencode($link->title);
-        $url .= '&st='.$link->from;
-        $url .= '&et='.$link->to;
+        $url .= '&st='.$link->from->format('Ymd\THis\Z');
+        $url .= '&dur='.date_diff($link->from, $link->to)->format("%H%I");
 
         if ($link->description) {
             $url .= '&desc='.urlencode($link->description);

--- a/tests/Generators/__snapshots__/YahooGeneratorTest__it_can_generate_a_yahoo_link__1.php
+++ b/tests/Generators/__snapshots__/YahooGeneratorTest__it_can_generate_a_yahoo_link__1.php
@@ -1,3 +1,3 @@
 <?php
 
-return 'https://calendar.yahoo.com/?v=60&view=d&type=20&title=Birthday&st=20180201T090000&et=20180201T180000&desc=With+clowns+and+stuff&in_loc=Party+Lane+1A%2C+1337+Funtown';
+return 'https://calendar.yahoo.com/?v=60&view=d&type=20&title=Birthday&st=20180201T090000Z&dur=1000&desc=With+clowns+and+stuff&in_loc=Party+Lane+1A%2C+1337+Funtown';


### PR DESCRIPTION
This pull request fix:
1.) Fixed timezone issue for yahoo calendar.
2.) Added duration parameter to specify calendar duration in half hour i.e. like for 1.5 hour, 2.5 hours.

The resulting url will be something like this.
https://calendar.yahoo.com/?v=60&view=d&type=20&title=title&st=20180201T080000Z&dur=0030