### PR TITLE
Added attendees and VTIMEZONE component to the ics file

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -39,7 +39,7 @@ class Ics implements Generator
         if ($link->address) {
             $url[] = 'LOCATION:'.$this->escapeString($link->address);
         }
-        if (!empty($link->attendees)) {
+        if (! empty($link->attendees)) {
             foreach ($link->attendees as $attendee) {
                 $url[] = 'ATTENDEE:'.$attendee;
             }

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -39,7 +39,7 @@ class Ics implements Generator
         if ($link->address) {
             $url[] = 'LOCATION:'.$this->escapeString($link->address);
         }
-        if ($link->attendees) {
+        if (!empty($link->attendees)) {
             foreach ($link->attendees as $attendee) {
                 $url[] = 'ATTENDEE:'.$attendee;
             }

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -15,6 +15,9 @@ class Ics implements Generator
         $url = [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
+            'BEGIN:VTIMEZONE',
+            'TZID:'.$link->from->format('e'),
+            'END:VTIMEZONE',
             'BEGIN:VEVENT',
             'UID:'.$this->generateEventUid($link),
             'SUMMARY:'.$link->title,
@@ -35,6 +38,11 @@ class Ics implements Generator
         }
         if ($link->address) {
             $url[] = 'LOCATION:'.$this->escapeString($link->address);
+        }
+        if ($link->attendees) {
+            foreach($link->attendees as $attendee) {
+                $url[] = 'ATTENDEE:'.$attendee;
+            }
         }
 
         $url[] = 'END:VEVENT';

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -40,7 +40,7 @@ class Ics implements Generator
             $url[] = 'LOCATION:'.$this->escapeString($link->address);
         }
         if ($link->attendees) {
-            foreach($link->attendees as $attendee) {
+            foreach ($link->attendees as $attendee) {
                 $url[] = 'ATTENDEE:'.$attendee;
             }
         }

--- a/src/Link.php
+++ b/src/Link.php
@@ -16,6 +16,7 @@ use Spatie\CalendarLinks\Exceptions\InvalidLink;
  * @property-read string $description
  * @property-read string $address
  * @property-read bool $allDay
+ * @property-read array $attendees
  */
 class Link
 {

--- a/src/Link.php
+++ b/src/Link.php
@@ -37,6 +37,9 @@ class Link
     /** @var string */
     protected $address;
 
+    /** @var array */
+    protected $attendees;
+
     public function __construct(string $title, DateTime $from, DateTime $to, bool $allDay = false)
     {
         $this->title = $title;
@@ -89,6 +92,22 @@ class Link
     public function address(string $address)
     {
         $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * @param array $emails
+     *
+     * @return $this
+     */
+    public function attendees(string $attendees)
+    {
+        if (!is_array($attendees)) {
+            $attendees = explode(',', $attendees);
+        }
+
+        $this->attendees = $attendees;
 
         return $this;
     }

--- a/src/Link.php
+++ b/src/Link.php
@@ -103,7 +103,7 @@ class Link
      */
     public function attendees(string $attendees)
     {
-        if (!is_array($attendees)) {
+        if (! is_array($attendees)) {
             $attendees = explode(',', $attendees);
         }
 


### PR DESCRIPTION
Thunderbird was complaining about: "see error console unknown time zones are treated as the 'floating' local timezone", therefore I needed to add a new component to the response.
https://tools.ietf.org/html/rfc5545#page-28

I also needed to add a list of attendees (useful in the calendar.app for Apple OS) which can come in as a comma-separated list or an array.