### PR TITLE
ICS links: support all day events spanning multiple days

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -37,7 +37,7 @@ class Ics implements Generator
 
         if ($link->allDay) {
             $url[] = 'DTSTART:'.$link->from->format($dateTimeFormat);
-            $url[] = 'DURATION:P1D';
+            $url[] = 'DURATION:P'.($link->from->diff($link->to)->days + 1).'D';
         } else {
             $url[] = 'DTSTART;TZID='.$link->from->format($dateTimeFormat);
             $url[] = 'DTEND;TZID='.$link->to->format($dateTimeFormat);


### PR DESCRIPTION
I use the library for an event calendar type website, and we have events spanning multiple days, so thats why I made this change.
It's a bit silly with the createAllDay function (which already gets the number of days) and single day "allDay" events, but just using diffInDays in every case is the least amount if code necessary. Hope that's ok, else let me know!

Thanks!