### PR TITLE
Google link full timezone support

### DIFF
--- a/src/Generators/Google.php
+++ b/src/Generators/Google.php
@@ -35,8 +35,6 @@ class Google implements Generator
             $url .= '&location='.urlencode($link->address);
         }
 
-        $url .= '&sprop=&sprop=name:';
-
         return $url;
     }
 }

--- a/src/Generators/Google.php
+++ b/src/Generators/Google.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\CalendarLinks\Generators;
 
+use DateTimeZone;
 use Spatie\CalendarLinks\Generator;
 use Spatie\CalendarLinks\Link;
 
@@ -12,16 +13,17 @@ class Google implements Generator
 {
     /** @var string {@see https://www.php.net/manual/en/function.date.php} */
     protected $dateFormat = 'Ymd';
-    protected $dateTimeFormat = 'Ymd\THis';
+    protected $dateTimeFormat = 'Ymd\THis\Z';
 
     /** {@inheritDoc} */
     public function generate(Link $link): string
     {
         $url = 'https://calendar.google.com/calendar/render?action=TEMPLATE';
 
+        $utcStartDateTime = (clone $link->from)->setTimezone(new DateTimeZone('UTC'));
+        $utcEndDateTime = (clone $link->to)->setTimezone(new DateTimeZone('UTC'));
         $dateTimeFormat = $link->allDay ? $this->dateFormat : $this->dateTimeFormat;
-        $url .= '&dates='.$link->from->format($dateTimeFormat).'/'.$link->to->format($dateTimeFormat);
-        $url .= '&ctz='.$link->from->getTimezone()->getName();
+        $url .= '&dates='.$utcStartDateTime->format($dateTimeFormat).'/'.$utcEndDateTime->format($dateTimeFormat);
 
         $url .= '&text='.urlencode($link->title);
 

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link__1.php
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link__1.php
@@ -1,1 +1,1 @@
-<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191231T230000/20200101T010000&ctz=UTC&text=New+Year&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown&sprop=&sprop=name:';
+<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191231T230000Z/20200101T010000Z&text=New+Year&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown';

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.php
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.php
@@ -1,1 +1,1 @@
-<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180206&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown&sprop=&sprop=name:';
+<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180206&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown';

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_short_event_link__1.php
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_short_event_link__1.php
@@ -1,1 +1,1 @@
-<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201T090000/20180201T180000&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown&sprop=&sprop=name:';
+<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201T090000Z/20180201T180000Z&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown';

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.php
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.php
@@ -1,1 +1,1 @@
-<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180202&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown&sprop=&sprop=name:';
+<?php return 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180202&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown';


### PR DESCRIPTION
Fixes #105.

Google generator uses `ctz` to set timezone. But this parameter doesn't seem to work when you use a timezone abbreviation (e.g. EDT). Better way is to use UTC-based start/end datetime (Z-postfix) as is in Yahoo generator.

I also removed unused params `&sprop=&sprop=name:`