### PR TITLE
Sending Meeting Update

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -30,7 +30,7 @@ class Ics implements Generator
             'VERSION:2.0',
             'METHOD:'.($this->options['METHOD'] ?? ''),
             'BEGIN:VEVENT',
-            'ATTENDEE:ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.($this->options['ATTENDEE'] ?? '').':MAILTO:'.($this->options['ATTENDEE'] ?? '')
+            'ATTENDEE:ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.($this->options['ATTENDEE'] ?? '').':MAILTO:'.($this->options['ATTENDEE'] ?? ''),
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
             'STATUS:'.($this->options['STATUS'] ?? ''),

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -30,6 +30,8 @@ class Ics implements Generator
             'VERSION:2.0',
             'BEGIN:VEVENT',
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
+            'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
+            'STATUS:'.($this->options['SEQUENCE'] ?? ''),
             'SUMMARY:'.$this->escapeString($link->title),
         ];
 

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -32,6 +32,7 @@ class Ics implements Generator
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
             'STATUS:'.($this->options['STATUS'] ?? ''),
+            'METHOD:'.($this->options['METHOD'] ?? ''),
             'SUMMARY:'.$this->escapeString($link->title),
         ];
 

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -28,11 +28,11 @@ class Ics implements Generator
         $url = [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
+            'METHOD:'.($this->options['METHOD'] ?? ''),
             'BEGIN:VEVENT',
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
             'STATUS:'.($this->options['STATUS'] ?? ''),
-            'METHOD:'.($this->options['METHOD'] ?? ''),
             'SUMMARY:'.$this->escapeString($link->title),
         ];
 

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -30,6 +30,7 @@ class Ics implements Generator
             'VERSION:2.0',
             'METHOD:'.($this->options['METHOD'] ?? ''),
             'BEGIN:VEVENT',
+            'ATTENDEE:ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.($this->options['ATTENDEE'] ?? '').':MAILTO:'.($this->options['ATTENDEE'] ?? '')
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
             'STATUS:'.($this->options['STATUS'] ?? ''),

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -31,7 +31,7 @@ class Ics implements Generator
             'BEGIN:VEVENT',
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SEQUENCE:'.($this->options['SEQUENCE'] ?? ''),
-            'STATUS:'.($this->options['SEQUENCE'] ?? ''),
+            'STATUS:'.($this->options['STATUS'] ?? ''),
             'SUMMARY:'.$this->escapeString($link->title),
         ];
 


### PR DESCRIPTION
In order to send updates to existing meetings you must set the METHOD, ATTENDEE, SEQUENCE, and STATUS fields. In the current codebase it is not possible to set these fields.

Once these fields are set sending a `.ics` to Gmail, for example, will automatically update the event in Google Calendar without any user intervention.

The relevant specs are,

- STATUS: https://datatracker.ietf.org/doc/html/rfc2445#section-4.8.1.11
- METHOD: https://datatracker.ietf.org/doc/html/rfc2446#section-3.2 (there's more detail on rfc2446 but rfc2445 has the same field without the additional clarity, imo)
- ATTENDEE: https://datatracker.ietf.org/doc/html/rfc2445#section-4.8.4.1
- STATUS: https://datatracker.ietf.org/doc/html/rfc2445#section-4.8.1.11

----

I assume we'll need make updates for tests and some readme/doc updates, but we're using this change in production and I was curious if you'd be open for a PR to add the fields in.