### PR TITLE
Add ctz parameter to Google Links when timezone is specified in from and to

### DIFF
--- a/src/Generators/Google.php
+++ b/src/Generators/Google.php
@@ -24,6 +24,15 @@ class Google implements Generator
         $utcEndDateTime = (clone $link->to)->setTimezone(new DateTimeZone('UTC'));
         $dateTimeFormat = $link->allDay ? $this->dateFormat : $this->dateTimeFormat;
         $url .= '&dates='.$utcStartDateTime->format($dateTimeFormat).'/'.$utcEndDateTime->format($dateTimeFormat);
+        
+        // Add timezone name if it is specified in both from and to dates and is the same for both
+        if (
+            $link->from->getTimezone() !== false
+            && $link->to->getTimezone() !== false
+            && $link->from->getTimezone()->getName() === $link->to->getTimezone()->getName()
+        ) {
+            $url .= '&ctz=' . $link->from->getTimezone()->getName();
+        }
 
         $url .= '&text='.urlencode($link->title);
 

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link__1.txt
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link__1.txt
@@ -1,1 +1,1 @@
-https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191231T230000Z/20200101T010000Z&text=New+Year&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown
+https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20191231T230000Z/20200101T010000Z&ctz=UTC&text=New+Year&details=With+balloons%2C+clowns+and+stuff%0D%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.txt
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.txt
@@ -1,1 +1,1 @@
-https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180206&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown
+https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180206&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0D%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_short_event_link__1.txt
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_short_event_link__1.txt
@@ -1,1 +1,1 @@
-https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201T090000Z/20180201T180000Z&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown
+https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201T090000Z/20180201T180000Z&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0D%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown

--- a/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.txt
+++ b/tests/Generators/__snapshots__/GoogleGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.txt
@@ -1,1 +1,1 @@
-https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180202&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown
+https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20180201/20180202&ctz=UTC&text=Birthday&details=With+balloons%2C+clowns+and+stuff%0D%0ABring+a+dog%2C+bring+a+frog&location=Party+Lane+1A%2C+1337+Funtown


### PR DESCRIPTION
## Add ctz parameter to Google Cal links

By setting ctz parameter, Google Calendar will retain the time zone of the event when shown in the summary screen.
