### PR TITLE
Fix Outlook 2016 - ics: description shows no html formatting

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -44,7 +44,7 @@ class Ics implements Generator
         }
 
         if ($link->description) {
-            $url[] = 'DESCRIPTION:'.$this->escapeString($link->description);
+            $url[] = 'X-ALT-DESC;FMTTYPE=text/html:'.$this->escapeString($link->description);
         }
         if ($link->address) {
             $url[] = 'LOCATION:'.$this->escapeString($link->address);


### PR DESCRIPTION
Committer: Karthik Kumar Bodu <karthik.mvgr@gmail.com>

## Context and Purposes

**Problem** : The HTML formatting is lost when `DESCRIPTION` is used in the ICS file.

**Reference** : https://answers.microsoft.com/en-us/outlook_com/forum/all/outlook-2016-ics-description-shows-no-html/08d06cba-bfe4-4757-a052-adab64ea75a2?page=1

**Solution** : Using `X-ALT-DESC;FMTTYPE=text/html` will resolve the problem and will render the description if there are HTML tags.
