### PR TITLE
Add 'export' option to ICS generation to allow exporting the ICS source rather than creating a base64 link

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -56,6 +56,10 @@ class Ics implements Generator
 
         $url[] = 'END:VEVENT';
         $url[] = 'END:VCALENDAR';
+        
+        if ($this->options['export']) {
+          return implode("\r\n", $url);
+        }
 
         return $this->buildLink($url);
     }


### PR DESCRIPTION
This should basically take care of #125, #126, and #129.

I've noticed that calendar links on Apple devices can be kind of tricky, and the way that seems to work the best and most consistently is serving a generated ICS file. Currently, this isn't possible because the ICS generator returns a base64 encoded string, however with this newly added option you'd be able to have it return the ICS contents.

For example:

`generate-ics.php`:
```php
<?php
require_once('autoload.php');
header('Content-type: text/calendar; charset=utf-8');
header('Content-Disposition: attachment; filename=event.ics');
$link = new Spatie\CalendarLinks\Link($title, $start_date, $end_date);
echo $link->ics(array('export' => true));
exit;
?>
```

Then you could link to that file like this: `webcal://mywebsite.com/generate-ics.php` and it should work fine for Apple devices.

It should be noted that not all browsers support the webcal protocol, so I use a piece of JavaScript to update my links depending on the browser:

```js
function webcalify(selector) {
  var isApple = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
  
  if (isApple) {
    var links = document.querySelectorAll(selector || 'a.webcal')
    
    for (var i = 0; i < links.length; i++) {
      var link = links[i]
      var url = link.href
      
      link.href = url.replace(/(^\w+:|^)\/\//, 'webcal://')
    }
  }
}
```