### PR TITLE
Add two required parameters to improve ICS validation

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -37,9 +37,11 @@ class Ics implements Generator
         $dateTimeFormat = $link->allDay ? $this->dateFormat : $this->dateTimeFormat;
 
         if ($link->allDay) {
+            $url[] = 'DTSTAMP;TZID='.$link->from->format($dateTimeFormat);
             $url[] = 'DTSTART:'.$link->from->format($dateTimeFormat);
             $url[] = 'DURATION:P'.(max(1, $link->from->diff($link->to)->days)).'D';
         } else {
+            $url[] = 'DTSTAMP;TZID='.$link->from->format($dateTimeFormat);
             $url[] = 'DTSTART;TZID='.$link->from->format($dateTimeFormat);
             $url[] = 'DTEND;TZID='.$link->to->format($dateTimeFormat);
         }

--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -28,6 +28,7 @@ class Ics implements Generator
         $url = [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
+            'PRODID:Spatie Calendar Links',
             'BEGIN:VEVENT',
             'UID:'.($this->options['UID'] ?? $this->generateEventUid($link)),
             'SUMMARY:'.$this->escapeString($link->title),


### PR DESCRIPTION
## Context and Purposes

The generated ICS didn't pass validation. 
I added PRODID & DTSTAMP values per requirements:
* [RFC 5545 3.6](https://icalendar.org/iCalendar-RFC-5545/3-6-calendar-components.html)
* [RFC 5545 3.6.1](https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html)
