### PR TITLE
Update datetime format to include Z, remove Z from all-day dates

### DIFF
--- a/src/Generators/Ics.php
+++ b/src/Generators/Ics.php
@@ -13,7 +13,7 @@ class Ics implements Generator
     /** @var string {@see https://www.php.net/manual/en/function.date.php} */
     protected $dateFormat = 'Ymd';
     /** @var string */
-    protected $dateTimeFormat = 'Ymd\THis';
+    protected $dateTimeFormat = 'Ymd\THis\Z';
 
     /** @var array<non-empty-string, non-empty-string> */
     protected $options = [];
@@ -41,13 +41,13 @@ class Ics implements Generator
         $dateTimeFormat = $link->allDay ? $this->dateFormat : $this->dateTimeFormat;
 
         if ($link->allDay) {
-            $url[] = 'DTSTAMP:'.gmdate($dateTimeFormat, $link->from->getTimestamp()).'Z';
-            $url[] = 'DTSTART:'.gmdate($dateTimeFormat, $link->from->getTimestamp()).'Z';
+            $url[] = 'DTSTAMP:'.gmdate($dateTimeFormat, $link->from->getTimestamp());
+            $url[] = 'DTSTART:'.gmdate($dateTimeFormat, $link->from->getTimestamp());
             $url[] = 'DURATION:P'.(max(1, $link->from->diff($link->to)->days)).'D';
         } else {
-            $url[] = 'DTSTAMP:'.gmdate($dateTimeFormat, $link->from->getTimestamp()).'Z';
-            $url[] = 'DTSTART:'.gmdate($dateTimeFormat, $link->from->getTimestamp()).'Z';
-            $url[] = 'DTEND:'.gmdate($dateTimeFormat, $link->to->getTimestamp()).'Z';
+            $url[] = 'DTSTAMP:'.gmdate($dateTimeFormat, $link->from->getTimestamp());
+            $url[] = 'DTSTART:'.gmdate($dateTimeFormat, $link->from->getTimestamp());
+            $url[] = 'DTEND:'.gmdate($dateTimeFormat, $link->to->getTimestamp());
         }
 
         if ($link->description) {

--- a/tests/Generators/__snapshots__/IcsGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.txt
+++ b/tests/Generators/__snapshots__/IcsGeneratorTest__it_can_generate_a_multiple_days_event_link_with_allday_flag__1.txt
@@ -4,8 +4,8 @@ PRODID:Spatie calendar-links
 BEGIN:VEVENT
 UID:47e044bc36ced4538c62fc17c3ba087b
 SUMMARY:Birthday
-DTSTAMP:20180201Z
-DTSTART:20180201Z
+DTSTAMP:20180201
+DTSTART:20180201
 DURATION:P5D
 DESCRIPTION:With balloons\, clowns and stuff\nBring a dog\, bring a frog
 LOCATION:Party Lane 1A\, 1337 Funtown

--- a/tests/Generators/__snapshots__/IcsGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.txt
+++ b/tests/Generators/__snapshots__/IcsGeneratorTest__it_can_generate_a_single_day_allday_event_link__1.txt
@@ -4,8 +4,8 @@ PRODID:Spatie calendar-links
 BEGIN:VEVENT
 UID:aaf6b0d9a2c43d4a1c803a8c80793a08
 SUMMARY:Birthday
-DTSTAMP:20180201Z
-DTSTART:20180201Z
+DTSTAMP:20180201
+DTSTART:20180201
 DURATION:P1D
 DESCRIPTION:With balloons\, clowns and stuff\nBring a dog\, bring a frog
 LOCATION:Party Lane 1A\, 1337 Funtown


### PR DESCRIPTION
## Context and Purposes

While I was updating the unit tests, I noticed that Z was being appended to the date formats, but it should only be used for times. This updates the date time format so that Z is used for UTC times while the dates are left alone.