### PR TITLE
Update Google.php

### DIFF
--- a/src/Generators/Google.php
+++ b/src/Generators/Google.php
@@ -38,8 +38,11 @@ class Google implements Generator
 
         $dateTimeFormat = $link->allDay ? self::DATE_FORMAT : self::DATETIME_FORMAT;
         $url .= '&dates='.$link->from->format($dateTimeFormat).'/'.$link->to->format($dateTimeFormat);
-        $url .= '&ctz=' . $link->from->getTimezone()->getName();
         $url .= '&text='.urlencode($link->title);
+        
+        if (!$link->allDay) {
+            $url .= '&ctz=' . $link->from->getTimezone()->getName();
+        }
 
         if ($link->description) {
             $url .= '&details='.urlencode($link->description);


### PR DESCRIPTION
Fix: Exclude `ctz` Parameter for _All-Day_ Events to Resolve _Google Calendar Android Issue_

This PR addresses an issue with the generate method in the Google calendar link generator, specifically for all-day events on Android devices. When the ctz (timezone) parameter is included for all-day events, Android devices encounter problems interpreting the event duration correctly, leading to inaccurate calendar entries.


### Changes:
- Updated the generate method to conditionally exclude the `ctz` parameter if the event is an all-day event.
- This ensures that all-day events function as expected across platforms, especially on Android, by omitting the timezone parameter.

### Impact:
This fix improves compatibility and accuracy for **all-day** events on Android, resolving an existing issue where Android misinterprets **all-day** events when the `ctz` parameter is included.

### References:

- Fixes issue with all-day event compatibility on Android when ctz is passed in the URL.

### TEST CASE _(Same Event Link)_
All Day Event with CTZ Param (Test on Android : Google Calendar) - Issue
`https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20241101%2F20241103&details=EVENT_DESC&location=EVENT_LOCATION&text=EVENT_TITLE&ctz=UTC`

All Day Event Without CTZ Param (Test on Android : Google Calendar) - No Isse
`https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20241101%2F20241103&details=EVENT_DESC&location=EVENT_LOCATION&text=EVENT_TITL`

<!--
Provide an overview of WHY the work is taking place, assuming that the reviewer is not familiar with the context.

For ICS format changes, please provide links to the Specification (https://tools.ietf.org/html/rfc2445).

Pull requests without a descriptive title, thorough description, or tests will be closed.
-->
